### PR TITLE
Update composer/composer version constraint to support Composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=5.4.0"
   },
   "require-dev": {
-    "composer/composer": "~1.0",
+    "composer/composer": "~1.0 || ^2.0",
     "phpunit/phpunit": "~5.7",
     "satooshi/php-coveralls": "~1.0"
   },


### PR DESCRIPTION
Updates the `composer.json`s `composer/composer` version to allow composer v2 as well. 

Related to cweagans/composer-patches#309.

Thank you.